### PR TITLE
Squash commits by default

### DIFF
--- a/src/GitlabApi.ts
+++ b/src/GitlabApi.ts
@@ -46,6 +46,7 @@ export interface MergeRequest {
 interface MergeRequestUpdateData {
 	assignee_id?: number;
 	remove_source_branch?: boolean;
+	squash?: boolean;
 	labels?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,10 @@ const runMergeRequestCheckerLoop = async (user: User) => {
 	const assignedMergeRequests = await gitlabApi.getAssignedOpenedMergeRequests();
 	const possibleToAcceptMergeRequests = assignedMergeRequests.map(async (mergeRequest: MergeRequest) => {
 		if (REMOVE_BRANCH_AFTER_MERGE && !mergeRequest.force_remove_source_branch) {
-			console.log(`[MR] Marking MR to be removed after merge`);
+			console.log(`[MR] Marking MR to be squashed and branch removed after merge`);
 			await gitlabApi.updateMergeRequest(mergeRequest.project_id, mergeRequest.iid, {
 				remove_source_branch: true,
+				squash: true,
 			});
 		}
 


### PR DESCRIPTION
Maybe it should be configurable, but I kept it the same way as `remove_source_branch` is.