### PR TITLE
Support Openshift's Route

### DIFF
--- a/charts/gitlab-merger-bot/templates/_helpers.tpl
+++ b/charts/gitlab-merger-bot/templates/_helpers.tpl
@@ -32,6 +32,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "helm-chart.labels" -}}
+app: {{ include "gitlab-merger-bot.name" . }}
+chart: {{ include "gitlab-merger-bot.chart" . }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts
 */}}
 {{- define "gitlab-merger-bot.namespace" -}}

--- a/charts/gitlab-merger-bot/templates/deployment.yaml
+++ b/charts/gitlab-merger-bot/templates/deployment.yaml
@@ -8,10 +8,7 @@ metadata:
 {{ toYaml .Values.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ include "gitlab-merger-bot.name" . }}
-    chart: {{ include "gitlab-merger-bot.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "helm-chart.labels" . | nindent 4 }}
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}

--- a/charts/gitlab-merger-bot/templates/ingress.yml
+++ b/charts/gitlab-merger-bot/templates/ingress.yml
@@ -13,10 +13,7 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ include "gitlab-merger-bot.name" . }}
-    chart: {{ include "gitlab-merger-bot.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "helm-chart.labels" . | nindent 4 }}
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}

--- a/charts/gitlab-merger-bot/templates/route.yml
+++ b/charts/gitlab-merger-bot/templates/route.yml
@@ -1,0 +1,31 @@
+{{- if .Values.route.enabled }}
+{{- $fullName := include "gitlab-merger-bot.fullname" . -}}
+{{- $service := .Values.service -}}
+{{- $route := .Values.route -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "gitlab-merger-bot.namespace" . }}
+{{- if $route.annotations }}
+  annotations:
+{{ toYaml $route.annotations | indent 4 }}
+{{- end }}
+  labels:
+    {{- include "helm-chart.labels" . | nindent 4 }}
+{{- if $route.labels }}
+{{ toYaml $route.labels | indent 4 }}
+{{- end }}
+spec:
+  host: {{ $route.host }}
+  path: {{ $route.path }}
+  port:
+    targetPort: {{ $service.port }}
+  to:
+    kind: Service
+    name: {{ $fullName }}
+    weight: 100
+{{- if $route.tls.enabled }}
+  tls:
+    {{ toYaml $route.tls.config | nindent 4 }}
+{{- end}}

--- a/charts/gitlab-merger-bot/templates/service.yml
+++ b/charts/gitlab-merger-bot/templates/service.yml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled }}
+{{- if or .Values.ingress.enabled .Values.route.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,10 +9,7 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ include "gitlab-merger-bot.name" . }}
-    chart: {{ include "gitlab-merger-bot.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "helm-chart.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/charts/gitlab-merger-bot/values.yaml
+++ b/charts/gitlab-merger-bot/values.yaml
@@ -41,6 +41,26 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+route:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  # -- The hostname that should be used.
+  # If left empty, OpenShift will generate one for you with defaults.
+  host: "chart-example.local"
+  # -- Subpath of the route.
+  path: /
+  tls:
+    # If `true`, TLS is enabled for the Route
+    enabled: true
+    config:
+      # Insecure edge termination policy of the Route. Can be `None`, `Redirect`, or `Allow`
+      insecureEdgeTerminationPolicy: Redirect
+      # TLS termination of the route. Can be `edge`, `passthrough`, or `reencrypt`
+      termination: edge
+
 service:
   type: ClusterIP
   port: 4000


### PR DESCRIPTION
Hi,

Firstly, thank you for this bot :)
We recently migrated our monolithic application to Gitlab and have been struggling with the merge race scenario as Gitlab does not yet support merge trains with fast-forward merge.

We just did a two week experiment using this bot and got positive feedback from all the teams !

I am currently industrializing its deployment in ou environnement.
Needless to say the helm chart allowed us to setup our experiment in minutes !

However, we use Openshift  which use the `Route` Kind instead of Kubernetes's `Ingress`.
We therefore added this capability to the Helm chart.

This PR contains the addition of support for Openshift's `Route` Kind, in case someone else need it and in hope to not have to maintain a fork :)
I also took the liberty of factoring the chart's labels, if that's ok with you