### PR TITLE
ops: replace hardcoded docker namespace with variable for forks

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -33,4 +33,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: "pepakriz/gitlab-merger-bot:latest,pepakriz/gitlab-merger-bot:${{ env.RELEASE_VERSION }}",
+          tags: "${{ secrets.DOCKER_NAMESPACE }}/gitlab-merger-bot:latest,${{ secrets.DOCKER_NAMESPACE }}/gitlab-merger-bot:${{ env.RELEASE_VERSION }}",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pepakriz/gitlab-merger-bot:latest
+          tags: ${{ secrets.DOCKER_NAMESPACE }}/gitlab-merger-bot:latest


### PR DESCRIPTION
This PR replaces the hardcoded value of the docker namespace with a variable. This allows forks to build and tests their pull requests.

This only requires to setup a GitHub secret called `DOCKER_NAMESPACE` to make it all work.

@pepakriz I hope you consider this PR.